### PR TITLE
Fix error due to type cast in AsyncLock.hx line 58 for Java target

### DIFF
--- a/rx/AsyncLock.hx
+++ b/rx/AsyncLock.hx
@@ -55,7 +55,7 @@ class AsyncLock {
                     if (l.queue.isEmpty()) {
 
                         var value = function(l:RxAsyncLockState) { l.is_acquired = false; return l;}(lock.data);
-                        AtomicData.unsafe_set(value, lock);
+                        AtomicData.unsafe_set(cast value, lock);
                         return null;
                     } else {
                         return l.queue.pop() ;


### PR DESCRIPTION
Below is error I got, but fixed by adding `cast` to value.

```
/home/travis/haxe/lib/rxhaxe/git/rx/AsyncLock.hx:58: characters 54-58 : error: { queue : List<Void -> Void>, is_acquired : Bool, has_faulted : Bool } should be (l : rx.RxAsyncLockState) -> rx.RxAsyncLockState
/home/travis/haxe/lib/rxhaxe/git/rx/AsyncLock.hx:58: characters 54-58 :  have: rx.AtomicData<{ queue, is_acquired, has_faulted }>
/home/travis/haxe/lib/rxhaxe/git/rx/AsyncLock.hx:58: characters 54-58 :  want: rx.AtomicData<(...) -> ...>
/home/travis/haxe/lib/rxhaxe/git/rx/AsyncLock.hx:58: characters 54-58 : For function argument 'ad'
```